### PR TITLE
Expand feature of DUET to process logical specification.

### DIFF
--- a/src/bottomup.ml
+++ b/src/bottomup.ml
@@ -80,10 +80,12 @@ let idxes_of_size sz grammar nts sz2idxes spec =
           nidx := !nidx + 1;
           idx2node := BatMap.add idx (Leaf expr) !idx2node;
           idx2out := 
+            (* doing enumeration, don't use io-spec *)
             if !LogicalSpec.do_enumeration then
               !idx2out
             else BatMap.add idx (compute_signature spec expr) !idx2out;
           nt2out := 
+            (* doing enumeration, don't use io-spec *)
             if !LogicalSpec.do_enumeration then
               !nt2out
             else BatMap.add nt (BatSet.add (compute_signature spec (expr_of_idx idx)) (BatMap.find nt !nt2out)) !nt2out;
@@ -144,6 +146,7 @@ let idxes_of_size sz grammar nts sz2idxes spec =
                     let node = NonLeaf (BatMap.find rule !func2idx, acc) in
                     (* for equivalence param valuation *)
                     let new_spec = 
+                      (* doing enumeration, don't use io-spec *)
                       if !LogicalSpec.do_enumeration then
                         []
                       else
@@ -151,6 +154,7 @@ let idxes_of_size sz grammar nts sz2idxes spec =
                     in
                     try (
                       let out = 
+                        (* doing enumeration, don't use io-spec *)
                         if !LogicalSpec.do_enumeration then
                           []
                         else
@@ -160,10 +164,12 @@ let idxes_of_size sz grammar nts sz2idxes spec =
                       else
                         let _ = nt2out := 
                           if !LogicalSpec.do_enumeration then
+                            (* do not update for doing enumeration *)
                             !nt2out
                           else BatMap.add nt (BatSet.add out (BatMap.find nt !nt2out)) !nt2out in
                         let _ = idx2out :=  
                           if !LogicalSpec.do_enumeration then
+                            (* do not update for doing enumeration *)
                             !idx2out
                           else BatMap.add idx out !idx2out in
                         let _ = nidx := !nidx + 1 in
@@ -232,6 +238,7 @@ let rec enumerate sz nt is_start_nt grammar nts _ sz2idxes target_function_name 
     if success then (success, func)
     else
       let candidate = expr_of_idx idx in
+      (* is there any counter-example? *)
       let cex_opt = LogicalSpec.get_counter_example candidate target_function_name args_map [] in
       match cex_opt with
       | None -> (true, candidate)

--- a/src/bottomup.ml
+++ b/src/bottomup.ml
@@ -101,7 +101,7 @@ let idxes_of_size sz grammar nts sz2idxes spec =
       ) rules BatSet.empty in
       BatMap.add nt idxes nt2idxes
     ) nts BatMap.empty in
-    print_endline "done!";
+    (* print_endline "done!"; *)
     BatMap.add sz nt2idxes sz2idxes
   else (* sz > 1 *)
     let nt2idxes = BatSet.fold (fun nt nt2idxes -> 
@@ -120,7 +120,7 @@ let idxes_of_size sz grammar nts sz2idxes spec =
                 functype
               )
             in
-            print_endline (string_of_expr expr_for_now);
+            (* print_endline (string_of_expr expr_for_now); *)
             (* get partition *)
             let partitions = p (sz-1) (BatList.length children) in
             (* get indexes of node that can generate from nt *)

--- a/src/bottomup.ml
+++ b/src/bottomup.ml
@@ -101,6 +101,7 @@ let idxes_of_size sz grammar nts sz2idxes spec =
       ) rules BatSet.empty in
       BatMap.add nt idxes nt2idxes
     ) nts BatMap.empty in
+    print_endline "done!";
     BatMap.add sz nt2idxes sz2idxes
   else (* sz > 1 *)
     let nt2idxes = BatSet.fold (fun nt nt2idxes -> 
@@ -119,6 +120,7 @@ let idxes_of_size sz grammar nts sz2idxes spec =
                 functype
               )
             in
+            print_endline (string_of_expr expr_for_now);
             (* get partition *)
             let partitions = p (sz-1) (BatList.length children) in
             (* get indexes of node that can generate from nt *)
@@ -141,7 +143,12 @@ let idxes_of_size sz grammar nts sz2idxes spec =
                     let idx = !nidx in
                     let node = NonLeaf (BatMap.find rule !func2idx, acc) in
                     (* for equivalence param valuation *)
-                    let new_spec = BatList.map (fun x -> BatMap.find x !idx2out) acc in
+                    let new_spec = 
+                      if !LogicalSpec.do_enumeration then
+                        []
+                      else
+                        BatList.map (fun x -> BatMap.find x !idx2out) acc 
+                    in
                     try (
                       let out = 
                         if !LogicalSpec.do_enumeration then

--- a/src/bottomup.ml
+++ b/src/bottomup.ml
@@ -232,7 +232,7 @@ let rec enumerate sz nt is_start_nt grammar nts _ sz2idxes target_function_name 
     if success then (success, func)
     else
       let candidate = expr_of_idx idx in
-      let cex_opt = LogicalSpec.get_counter_example candidate target_function_name args_map in
+      let cex_opt = LogicalSpec.get_counter_example candidate target_function_name args_map [] in
       match cex_opt with
       | None -> (true, candidate)
       | Some _ -> (false, trivial)

--- a/src/compatibility.ml
+++ b/src/compatibility.ml
@@ -1,0 +1,183 @@
+open Exprs
+
+type compatibility = 
+  | Strong of bool 
+  | Weak of bool
+
+let get_bool c =
+  match c with
+  | Strong b -> b
+  | Weak b -> b
+
+let all_map = ref BatMap.empty
+let weak_stack = ref []
+let b_list = [[true; true]; [false; true]; [false; false]]
+let strong_idx = -1
+
+let is_compatible a b  =
+  try 
+    let (idx, b') = BatMap.find a !all_map in
+    if idx = strong_idx then 
+      Strong (b = b')
+    else 
+      Weak (b = b')
+  with Not_found -> Weak true
+
+let is_strong a = 
+  try 
+    let (idx, b) = BatMap.find a !all_map in
+    idx = strong_idx
+  with Not_found -> false
+
+let bool_to_const b =
+  CBool (Concrete b)
+
+exception StrongParadox (* can't fix *)
+exception WeakParadox (* can fix *)
+
+let add_strong a b = 
+  let cmp = is_compatible a b in
+  match cmp with
+  | Strong b' ->
+    if b' then ()
+    else raise StrongParadox
+  | Weak b' ->
+    if b' then 
+      all_map := BatMap.add a (strong_idx, b) !all_map
+    else
+      let _ = all_map := BatMap.add a (strong_idx, b) !all_map in 
+      raise WeakParadox 
+
+let add_weak a_list i =
+  assert (0 <= i && i <= 2);
+  assert (BatList.length a_list = 2);
+  let tmp_map = ref !all_map in
+  let _ = BatList.iter (fun (a, b) ->
+    let cmp = is_compatible a b in
+    match cmp with
+    | Strong b' ->
+      if b' then ()
+      else raise WeakParadox
+    | Weak b' ->
+      if b' then 
+        if not (BatMap.mem a !tmp_map) then
+          tmp_map := BatMap.add a (BatList.length !weak_stack, b) !tmp_map
+        else 
+          ()
+      else
+        raise WeakParadox
+  ) (BatList.combine a_list (BatList.nth b_list i)) in 
+  let _ = all_map := !tmp_map in
+  weak_stack := (a_list, i) :: !weak_stack
+
+(* return (sig, bool option) list *)
+let rec modify () =
+  if BatList.is_empty !weak_stack then raise StrongParadox
+  else
+    let (aa, out_ty) = BatList.hd !weak_stack in
+    if out_ty = 2 then
+      let _ = weak_stack := BatList.tl !weak_stack in
+      let rtn : (const list * bool option) list = modify () in
+      let rtn = 
+        if is_strong (BatList.nth aa 1) then rtn 
+        else ((BatList.nth aa 1, None) :: rtn) in
+      let rtn = 
+        if is_strong (BatList.nth aa 0) then rtn 
+        else ((BatList.nth aa 0, None) :: rtn) in
+      rtn 
+    else 
+      try
+        let _ = weak_stack := BatList.tl !weak_stack in
+        let _ = add_weak aa (out_ty + 1) in
+        let bb = BatList.nth b_list (out_ty + 1) in
+        let a_x_b = BatList.combine aa bb in
+        BatList.fold_left (fun acc (a, b) ->
+          (a, Some b) :: acc
+        ) [] a_x_b 
+      with WeakParadox ->
+        let _ = weak_stack := (aa, out_ty + 1) :: !weak_stack in
+        modify ()
+
+let is_in_stack a = 
+  BatList.exists (fun (aa, _) -> BatList.mem a aa) !weak_stack
+
+let rec pop_and_modify a = 
+  assert (is_in_stack a);
+  let (aa, out_ty) = BatList.hd !weak_stack in
+  if BatList.mem a aa then
+    modify ()
+  else 
+    let _ = weak_stack := BatList.tl !weak_stack in
+    let rtn = pop_and_modify a in
+    let rtn = 
+      if is_strong (BatList.nth aa 1) then rtn 
+      else ((BatList.nth aa 1, None) :: rtn) in
+    let rtn = 
+      if is_strong (BatList.nth aa 0) then rtn 
+      else ((BatList.nth aa 0, None) :: rtn) in
+    rtn
+
+let revise_spec spec plan = 
+  let plan_map = 
+    BatList.fold_left (fun acc (a, opt) ->
+      BatMap.add a opt acc 
+    ) BatMap.empty plan 
+  in
+  BatList.fold_left (fun acc (i, o) ->
+    if BatMap.mem i plan_map then 
+      let opt = BatMap.find i plan_map in
+      match opt with
+      | Some b -> (i, bool_to_const b) :: acc
+      | None -> acc
+    else
+      (i, o) :: acc
+  ) [] spec
+
+let add_if_does_not_exist (new_i, new_o) spec = 
+  if BatList.exists (fun (i, _) -> i = new_i) spec then
+    spec
+  else
+    (new_i, new_o) :: spec
+
+let add_strong_spec a b spec =
+  try
+    let _ = add_strong a b in
+    (a, bool_to_const b) :: spec
+  with 
+  | StrongParadox ->
+    failwith "There's no such loop invariant that fulfills given constraints.";
+  | WeakParadox -> (
+    try 
+      let plan = pop_and_modify a in
+      add_if_does_not_exist (a, bool_to_const b) (revise_spec spec plan)
+    with StrongParadox ->
+      failwith "There's no such loop invariant that fulfills given constraints.";
+  )
+
+let modify_spec spec = 
+  try 
+    let plan = modify () in
+    revise_spec spec plan
+  with StrongParadox -> (
+    failwith "There's no such loop invariant that fulfills given constraints.";
+  )
+
+let add_weak_spec aa spec =
+  let rec add_weak_iter i =
+    if i = 3 then
+      let plan = modify () in
+      revise_spec spec plan
+    else
+      try
+        let _ = add_weak aa i in
+        let a_x_b  = BatList.combine aa (BatList.nth b_list i) in
+        BatList.fold_left (fun acc (a, b) ->
+          add_if_does_not_exist (a, bool_to_const b) acc
+        ) spec a_x_b
+      with WeakParadox ->
+        add_weak_iter (i + 1)
+  in
+  try
+    add_weak_iter 0
+  with StrongParadox ->
+    failwith "There's no such loop invariant that fulfills given constraints.";

--- a/src/compatibility.ml
+++ b/src/compatibility.ml
@@ -1,26 +1,40 @@
 open Exprs
 open Vocab
 
+(* Can given new io-spec be compatible with old io-spec? *)
+(* Strong true/false : always can/can't be *)
+(* Weak   true/false : can/can't be for now *)
 type compatibility = 
   | Strong of bool 
   | Weak of bool
+
+(* how to modify a io-spec *)
+(* ( [c0;c1;c2], None        ) -> delete [c0;c1;c2] from io-spec *)
+(* ( [c0;c1;c2], Some (true) ) -> modify (or add) f(c0, c1, c2) = true *)
+type plan = (const list * bool option) list
 
 let get_bool c =
   match c with
   | Strong b -> b
   | Weak b -> b
 
-let all_map = ref BatMap.empty
-let weak_stack = ref []
+(* map for all of io-spec *)
+(* ex. [0;3] -> (-1, true) : f(0, 3) = true  is always true. *)
+(* ex. [1;2] -> (0, false) : f(1, 2) = false is in weak-stack, and its idx is 0.  *)
+let all_map : (const list, (int * bool)) BatMap.t ref = ref BatMap.empty
+(* stack for io-spec that may not be compatible. the more sooner io-spec is in stack, the stronger *)
+(* ex. ( [[0;1]; [2;3]], 0 ) : f(0, 1) = true /\ f(2, 3) = true. the pair of inputs matches their output according to b_list  *)
+let weak_stack : ((const list) list * int) list ref = ref []
 let b_list = [[true; true]; [false; true]; [false; false]]
-let strong_idx = -1
+let strong_idx = -1 (* for strong io-specs in the all_map *)
 
 let string_of_stack s = 
   string_of_list (fun (aa, i) -> 
     (string_of_list (string_of_list string_of_const) aa) ^ " " ^ (string_of_int i)
   ) s
 
-let is_compatible a b  =
+(* is f(A) = B compatible? *)
+let is_compatible (a:const list) (b:bool)  =
   try 
     let (idx, b') = BatMap.find a !all_map in
     if idx = strong_idx then 
@@ -29,7 +43,8 @@ let is_compatible a b  =
       Weak (b = b')
   with Not_found -> Weak true
 
-let is_strong a = 
+(* is there strong io-spec when input is A? *)
+let is_strong (a:const list) = 
   try 
     let (idx, b) = BatMap.find a !all_map in
     idx = strong_idx
@@ -41,7 +56,8 @@ let bool_to_const b =
 exception StrongParadox (* can't fix *)
 exception WeakParadox (* can fix *)
 
-let add_strong a b = 
+(* add strong io-spec that f(A) = B *)
+let add_strong (a:const list) (b:bool) = 
   let cmp = is_compatible a b in
   match cmp with
   | Strong b' ->
@@ -54,9 +70,13 @@ let add_strong a b =
       let _ = all_map := BatMap.add a (strong_idx, b) !all_map in 
       raise WeakParadox 
 
-let add_weak a_list i =
+(* add weak io-spec *)
+(* aa = [a_0 ; a_1] *)
+(* bb = [b_0 ; b_1] which its index is i at b_list *)
+(* f(a_0) = b_0 /\ f(a_1) = b_1 *)
+let add_weak (aa: (const list) list) (i: int) =
   assert (0 <= i && i <= 2);
-  assert (BatList.length a_list = 2);
+  assert (BatList.length aa = 2);
   let tmp_map = ref !all_map in
   let _ = BatList.iter (fun (a, b) ->
     let cmp = is_compatible a b in
@@ -72,11 +92,12 @@ let add_weak a_list i =
           ()
       else
         raise WeakParadox
-  ) (BatList.combine a_list (BatList.nth b_list i)) in 
+  ) (BatList.combine aa (BatList.nth b_list i)) in 
   let _ = all_map := !tmp_map in
-  weak_stack := (a_list, i) :: !weak_stack
+  weak_stack := (aa, i) :: !weak_stack
 
-let remove_weak aa = 
+(* remove weak io-specs from all_map *)
+let remove_weak (a_list: (const list) list) = 
   all_map := BatList.fold_left (fun acc a ->
     if BatMap.mem a !all_map then
       let (idx, b) = BatMap.find a !all_map in
@@ -86,10 +107,12 @@ let remove_weak aa =
         BatMap.remove a acc
     else
       acc
-  ) !all_map aa
+  ) !all_map a_list
 
-(* return (sig, bool option) list *)
-let rec modify () =
+(* modify the top element of weak_stack to increase its output type by 1 *)
+(* if its output type equals 2, pop it from weak_stack and modify the next top element recursively *)
+(* returns plan that makes modified io-spec from old io-spec *)
+let rec modify () : plan =
   if BatList.is_empty !weak_stack then raise StrongParadox
   else
     let (aa, out_ty) = BatList.hd !weak_stack in
@@ -121,7 +144,8 @@ let rec modify () =
 let is_in_stack a = 
   BatList.exists (fun (aa, _) -> BatList.mem a aa) !weak_stack
 
-let rec pop_and_modify a = 
+(* pop elements from weak_stack until a is not in weak_stack, then use function 'modify' *)
+let rec pop_and_modify a : plan = 
   assert (is_in_stack a);
   let (aa, out_ty) = BatList.hd !weak_stack in
   if BatList.mem a aa then
@@ -138,11 +162,12 @@ let rec pop_and_modify a =
       else ((BatList.nth aa 0, None) :: rtn) in
     rtn
 
-let revise_spec spec plan = 
+(* revise io-spec to modified io-spec by using 'plan' *)
+let revise_spec spec plan' = 
   let plan_map = 
     BatList.fold_left (fun acc (a, opt) ->
       BatMap.add a opt acc 
-    ) BatMap.empty plan 
+    ) BatMap.empty plan'
   in
   BatList.fold_left (fun acc (i, o) ->
     if BatMap.mem i plan_map then 
@@ -160,6 +185,8 @@ let add_if_does_not_exist (new_i, new_o) spec =
   else
     (new_i, new_o) :: spec
 
+(* add strong io-spec using function 'add_strong' *)
+(* if there is any paradox, handle it by modifying io-spec *)
 let add_strong_spec a b spec =
   try
     let _ = add_strong a b in
@@ -169,25 +196,29 @@ let add_strong_spec a b spec =
     failwith "There's no such loop invariant that fulfills given constraints.";
   | WeakParadox -> (
     try 
-      let plan = pop_and_modify a in
-      add_if_does_not_exist (a, bool_to_const b) (revise_spec spec plan)
+      let plan' = pop_and_modify a in
+      add_if_does_not_exist (a, bool_to_const b) (revise_spec spec plan')
     with StrongParadox ->
       failwith "There's no such loop invariant that fulfills given constraints.";
   )
 
+(* modify io-spec using function 'modify' *)
+(* if there is any paradox, handle it by modifying io-spec *)
 let modify_spec spec = 
   try 
-    let plan = modify () in
-    revise_spec spec plan
+    let plan' = modify () in
+    revise_spec spec plan'
   with StrongParadox -> (
     failwith "There's no such loop invariant that fulfills given constraints.";
   )
 
+(* add weak io-spec using function 'add_weak' *)
+(* if there is any paradox, handle it by modifying io-spec *)
 let add_weak_spec aa idx spec =
   let rec add_weak_iter i =
     if i = 3 then
-      let plan = modify () in
-      revise_spec spec plan
+      let plan' = modify () in
+      revise_spec spec plan'
     else
       try
         let _ = add_weak aa i in

--- a/src/compatibility.ml
+++ b/src/compatibility.ml
@@ -162,7 +162,7 @@ let modify_spec spec =
     failwith "There's no such loop invariant that fulfills given constraints.";
   )
 
-let add_weak_spec aa spec =
+let add_weak_spec aa idx spec =
   let rec add_weak_iter i =
     if i = 3 then
       let plan = modify () in
@@ -178,6 +178,6 @@ let add_weak_spec aa spec =
         add_weak_iter (i + 1)
   in
   try
-    add_weak_iter 0
+    add_weak_iter idx
   with StrongParadox ->
     failwith "There's no such loop invariant that fulfills given constraints.";

--- a/src/exprs.ml
+++ b/src/exprs.ml
@@ -412,7 +412,10 @@ let fun_apply_signature op values =
 		List.map2 (fun num1 num2 -> CInt (num1 + num2)) num1s num2s 
 	else if (String.compare op "-") = 0 then
 		let num1s = List.map get_int (List.nth values 0) in
-		let num2s = List.map get_int (List.nth values 1) in
+		(* let num2s = List.map get_int (List.nth values 1) in *)
+		let num2s = try List.map get_int (List.nth values 1)
+		 (* if 'values' is too short, use '-' as unary operator  *)
+			with Failure _ -> List.map (fun x -> 2*x) num1s in 
 		List.map2 (fun num1 num2 -> CInt (num1 - num2)) num1s num2s
 	else if (String.compare op "*") = 0 then
 		let num1s = List.map get_int (List.nth values 0) in

--- a/src/exprs.ml
+++ b/src/exprs.ml
@@ -425,7 +425,7 @@ let fun_apply_signature op values =
 		let num1s = List.map get_int (List.nth values 0) in
 		let num2s = List.map get_int (List.nth values 1) in
 		List.map2 (fun num1 num2 -> CInt (num1 / num2)) num1s num2s
-	else if (String.compare op "%") = 0 then
+	else if (String.compare op "%") = 0 || (String.compare op "mod") = 0 then
 		let num1s = List.map get_int (List.nth values 0) in
 		let num2s = List.map get_int (List.nth values 1) in
 		List.map2 (fun num1 num2 -> CInt (num1 mod num2)) num1s num2s

--- a/src/grammar.ml
+++ b/src/grammar.ml
@@ -38,6 +38,7 @@ let ret_type_of_op rule =
 	else if (String.compare op ">") = 0 then Bool
 	else if (String.compare op "<=") = 0 then Bool
 	else if (String.compare op ">=") = 0 then Bool
+	else if (String.compare op "=>") = 0 then Bool
 	else if (String.compare op "ite") = 0 then  
 		let nts = get_nts rule in 
 		let _ = assert ((BatList.length nts) = 3) in 

--- a/src/logicalSpec.ml
+++ b/src/logicalSpec.ml
@@ -1,0 +1,22 @@
+open Sexplib
+open Vocab
+open Exprs
+open Z3
+open BidirectionalUtils
+
+type t = (Exprs.expr) list
+let empty_spec = []
+
+(* constraints that consist of logical spec *)
+let logical_spec = ref empty_spec
+let add_constraint e = 
+	logical_spec := (e :: !logical_spec)
+
+let get_counter_example sol spec = 
+	if !logical_spec = [] then None (* can't found logical spec *)
+	else 
+		let ctx = Z3.mk_context	[("model", "true"); ("proof", "false")] in
+		(* STEP 01 : make logical spec to one expression (combine by 'and') *)
+		(* STEP 02 : resolve target function *)
+		(* STEP 03 : make Z3 query *)
+		(* STEP 04 : get cex-in as counter example *)

--- a/src/logicalSpec.ml
+++ b/src/logicalSpec.ml
@@ -185,7 +185,10 @@ let rec make_cex_in target_function_name cex_in_map expr =
 		if op = target_function_name then
 			let rec resolve_var_to_const expr =
 				match expr with
-				| Var (id, _) -> BatMap.find id cex_in_map
+				| Var (id, ty) -> (
+					try BatMap.find id cex_in_map 
+					with Not_found -> Const (get_trivial_value ty)
+				)
 				| Function (op, exprs, ty) -> 
 					Function (op, BatList.map resolve_var_to_const exprs, ty)
 				| _ -> expr
@@ -243,6 +246,7 @@ let get_counter_example sol target_function_name args_map old_spec =
 			if (Option.is_some pre_opt) then (
 				match pre_opt with
 				| Some cex_var_map -> (
+					(* print_endline "pre_opt is Some cex_var_map"; *)
 					let cex_in = make_cex_in target_function_name cex_var_map !pre_constraint in
 					assert ((BatList.length cex_in) = 1);
 					let cex_in = BatList.hd cex_in in
@@ -254,6 +258,8 @@ let get_counter_example sol target_function_name args_map old_spec =
 			else if (Option.is_some (process_z3query post_z3query)) then (
 				match post_opt with
 				| Some cex_var_map -> (
+					(* print_endline "post_opt is Some cex_var_map"; *)
+					(* print_endline (string_of_map (fun x -> x) string_of_expr cex_var_map); *)
 					let cex_in = make_cex_in target_function_name cex_var_map !post_constraint in
 					assert ((BatList.length cex_in) = 1);
 					let cex_in = BatList.hd cex_in in
@@ -266,6 +272,7 @@ let get_counter_example sol target_function_name args_map old_spec =
 				(* Some (BatSet.empty) *)
 				match trans_opt with
 				| Some cex_var_map -> (
+					(* print_endline "trans_opt is Some cex_var_map"; *)
 					let cex_in = make_cex_in target_function_name cex_var_map !trans_constraint in
 					assert ((BatList.length cex_in) = 2);
 					(* always give two counter-examples. x = x' doesn't happen. *)

--- a/src/logicalSpec.ml
+++ b/src/logicalSpec.ml
@@ -105,7 +105,7 @@ let rec resolve_expr sol target_function_name expr  =
 		else Function (op, BatList.map (resolve_expr sol target_function_name) exprs, ty)
 	| _ -> expr
 
-let get_counter_example sol iospec target_function_name args_map = 
+let get_counter_example sol target_function_name args_map = 
 	if !spec = [] then None (* can't found logical spec *)
 	else 
 		let ctx = Z3.mk_context	[("model", "true"); ("proof", "false")] in
@@ -126,9 +126,9 @@ let get_counter_example sol iospec target_function_name args_map =
 				BatMap.add param_expr (Var(id, ty)) acc  
 			) args_map BatMap.empty
 		in *)
-		print_endline ("combined_spec : " ^ (string_of_expr combined_spec));
+		(* print_endline ("combined_spec : " ^ (string_of_expr combined_spec)); *)
 		let combined = resolve_expr sol target_function_name combined_spec in
-		print_endline ("combined : " ^ (string_of_expr combined));
+		(* print_endline ("combined : " ^ (string_of_expr combined)); *)
 		(* STEP 03 : make Z3 query *)
 		let params_str = 
 			begin
@@ -177,7 +177,7 @@ let get_counter_example sol iospec target_function_name args_map =
 					BatMap.add id (Const (List.hd (evaluate_expr_faster [[CInt 0]] (sexp_to_cex sexp)))) acc
 					(* BatMap.add id (Const (CInt (-2))) acc *)
 				) !forall_var_map BatMap.empty in
-				print_endline ("cex_var_map : " ^ (string_of_map (fun e -> e) string_of_expr cex_var_map));
+				(* print_endline ("cex_var_map : " ^ (string_of_map (fun e -> e) string_of_expr cex_var_map)); *)
 				Some (cex_var_map)
 		end
 		in 
@@ -196,7 +196,7 @@ let get_counter_example sol iospec target_function_name args_map =
 				) !target_params (BatMap.empty, [])
 			in
 			let combined = plug_in combined_spec target_function_name cex_var_map (param2sig, sig_list) in
-			print_endline ("combined : " ^ (string_of_expr combined));
+			(* print_endline ("combined : " ^ (string_of_expr combined)); *)
 			let _, params_str = 
 				begin
 					BatList.fold_left (fun (idx, acc) sig_in ->
@@ -237,15 +237,15 @@ let get_counter_example sol iospec target_function_name args_map =
 								((String.length target_function_name) + (String.length !identifier) ) 
 								((String.length sig_id) - ((String.length target_function_name) + (String.length !identifier)))
 							in
-							print_endline ("id_parse : " ^ id_parse);
+							(* print_endline ("id_parse : " ^ id_parse); *)
 							let sig_idx = int_of_string id_parse in
 							let sig_in = List.nth sig_list sig_idx in
 							let sexp = Parsexp.Single.parse_string_exn (Z3.Expr.to_string z3expr) in
 					 		let sig_out = List.hd (evaluate_expr_faster [[CInt 0]] (sexp_to_cex sexp)) in 
 							BatSet.add (sig_in, sig_out) acc
 					)	name2expr BatSet.empty in
-					print_endline ("cex_all : " ^ (string_of_set (fun (sig_in, sig_out) -> 
-						(string_of_list string_of_const sig_in) ^ " -> " ^ (string_of_const sig_out)) cex_all));
+					(* print_endline ("cex_all : " ^ (string_of_set (fun (sig_in, sig_out) -> 
+						(string_of_list string_of_const sig_in) ^ " -> " ^ (string_of_const sig_out)) cex_all)); *)
 					Some (cex_all)
 			end
 			| _ -> assert false
@@ -254,8 +254,8 @@ let get_counter_example sol iospec target_function_name args_map =
 		cex
 ;;
 
-let add_trivial_examples iospec target_function_name args_map =
+let add_trivial_examples target_function_name args_map =
 	let trivial_sol = 
 		Exprs.Const (Exprs.get_trivial_value (Grammar.type_of_nt Grammar.start_nt))
 	in
-	get_counter_example trivial_sol iospec target_function_name args_map
+	get_counter_example trivial_sol target_function_name args_map

--- a/src/logicalSpec.ml
+++ b/src/logicalSpec.ml
@@ -3,6 +3,7 @@ open Vocab
 open Exprs
 open Z3
 open BidirectionalUtils
+open Compatibility
 
 let rec string_of_sexp sexp = 
 	match sexp with
@@ -245,7 +246,7 @@ let get_counter_example sol target_function_name args_map old_spec =
 					let cex_in = make_cex_in target_function_name cex_var_map !pre_constraint in
 					assert ((BatList.length cex_in) = 1);
 					let cex_in = BatList.hd cex_in in
-					Some ((cex_in, CBool (Concrete true))::old_spec)
+					Some (add_strong_spec cex_in true old_spec)
 				)
 				| None -> assert false
 			)
@@ -256,7 +257,7 @@ let get_counter_example sol target_function_name args_map old_spec =
 					let cex_in = make_cex_in target_function_name cex_var_map !post_constraint in
 					assert ((BatList.length cex_in) = 1);
 					let cex_in = BatList.hd cex_in in
-					Some ((cex_in, CBool (Concrete false))::old_spec)
+					Some (add_strong_spec cex_in false old_spec)
 				)
 				| None -> assert false
 			)
@@ -278,7 +279,7 @@ let get_counter_example sol target_function_name args_map old_spec =
 					then (BatList.nth cex_in 0, BatList.nth cex_in 1)
 					else (BatList.nth cex_in 1, BatList.nth cex_in 0)
 					in	
-					failwith "not implemented: counter-example for transition function";
+					Some (add_weak_spec [l;l'] old_spec)
 				)
 				| None -> assert false
 			)

--- a/src/logicalSpec.ml
+++ b/src/logicalSpec.ml
@@ -251,7 +251,7 @@ let get_counter_example sol iospec target_function_name args_map =
 			| _ -> assert false
 		end 
 		in 
-		None
+		cex
 ;;
 
 let add_trivial_examples iospec target_function_name args_map =

--- a/src/logicalSpec.ml
+++ b/src/logicalSpec.ml
@@ -179,6 +179,38 @@ let process_z3query z3query =
 		in 
 		cex_var_map_opt
 
+let rec get_out_ty args_map l_list target_function_name i =
+	if i = 3 then i
+	else
+		let bb = BatList.nth b_list i in
+		let l_x_b  = BatList.combine l_list bb in
+		let no_paradox = BatList.for_all (fun (l, b) ->
+			let now_constraint = 
+				if b then !post_constraint
+				else !pre_constraint
+			in
+			let cex_var_map = 
+				BatMap.foldi (fun id param acc ->
+					match param with
+					| Param(pos, ty) ->
+						try 
+							let expr = Const (BatList.nth l pos) in
+							BatMap.add id expr acc
+						with _ -> acc
+					| _ -> assert false
+				) args_map BatMap.empty
+			in
+			let resolved = resolve_expr (Const (CBool (Concrete b))) target_function_name now_constraint in
+			let plugged = plug_in resolved target_function_name cex_var_map (BatMap.empty, []) in
+			let z3query = Printf.sprintf "(assert %s)" (Exprs.string_of_expr plugged) in
+			let opt = process_z3query z3query in
+			Option.is_some opt
+		) l_x_b
+		in 
+		if no_paradox then i 
+		else get_out_ty args_map l_list target_function_name (i + 1)
+
+
 let rec make_cex_in target_function_name cex_in_map expr =
 	match expr with
 	| Function (op, exprs, ty) ->
@@ -279,7 +311,8 @@ let get_counter_example sol target_function_name args_map old_spec =
 					then (BatList.nth cex_in 0, BatList.nth cex_in 1)
 					else (BatList.nth cex_in 1, BatList.nth cex_in 0)
 					in	
-					Some (add_weak_spec [l;l'] old_spec)
+					let idx = get_out_ty args_map [l;l'] target_function_name 0 in
+					Some (add_weak_spec [l;l'] idx old_spec)
 				)
 				| None -> assert false
 			)

--- a/src/logicalSpec.ml
+++ b/src/logicalSpec.ml
@@ -9,12 +9,25 @@ let empty_spec : t = []
 
 (* constraints that consist of logical spec *)
 let spec = ref empty_spec
-let add_constraint e = 
-	spec := (e :: !spec)
+let target_params : (Exprs.expr list) BatSet.t ref = ref BatSet.empty
 
-	let forall_var_map : (string, Exprs.expr) BatMap.t ref =
-		(* name -> Var *) 
-		ref BatMap.empty
+let add_constraint e target_function_name = 
+	let _ = spec := (e :: !spec) in (* add constraints to spec *)
+	(* add parameters of target_function to target_params *)
+	let rec find_params e target_function_name =
+		match e with
+		| Function (op, exprs, _) -> 
+			if op = target_function_name then
+				target_params := BatSet.add exprs !target_params
+			else
+				BatList.iter (fun e -> find_params e target_function_name) exprs
+		| _ -> ()
+	in
+	find_params e target_function_name	
+
+let forall_var_map : (string, Exprs.expr) BatMap.t ref =
+	(* name -> Var *) 
+	ref BatMap.empty
 
 let string_of_logical_spec logical_spec = 
 	string_of_list string_of_expr logical_spec
@@ -55,19 +68,43 @@ let get_counter_example sol iospec target_function_name args_map =
 					| Var (id, ty) -> 
 						Printf.sprintf "%s\n(declare-const %s %s)" 
 						acc id (string_of_type ~z3:true ty)
-					| -> assert false
+					| _ -> assert false
 				) !forall_var_map ""
 			end
 		in
-		let z3query = params_str ^ (Printf.sprintf "\n(assert (not %s))" Exprs.string_of_expr combined) in
+		let z3query = params_str ^ (Printf.sprintf "\n(assert (not %s))" (Exprs.string_of_expr combined)) in
 		(* process query *)
-    let exprSMT = Z3.SMT.parse_smtlib2_string ctx str [] [] [] [] in (* Z3.AST.ASTVector.ast_vector *)
+    let exprSMT = Z3.SMT.parse_smtlib2_string ctx z3query [] [] [] [] in (* Z3.AST.ASTVector.ast_vector *)
     let sat = Z3.AST.ASTVector.to_expr_list exprSMT in (* Z3.Expr.expr list *)
     let solver = (Z3.Solver.mk_solver ctx None) in (* Z3.Solver.solver *)
   	(Z3.Solver.add solver sat);
     let q = (Z3.Solver.check solver []) in (* ZMT.Solver.status *)
 		(* STEP 04 : get cex-in as counter example *)
-		None
+		match q with
+    | UNSATISFIABLE -> None
+    | UNKNOWN -> assert false
+    | SATISFIABLE -> 
+      let model_opt = Z3.Solver.get_model solver in
+      match model_opt with
+      | None -> assert false
+      | Some model ->
+        (* ex. (define-fun arg_0 () Bool false) (define-fun arg_2 () Bool true) (define-fun arg_1 () Bool false) *)
+        let decls = Z3.Model.get_decls model in (* vs. get_func_decls - only function delcarations *)
+        let name2expr = BatList.fold_right (fun decl acc -> 
+          let name = Z3.Symbol.to_string (Z3.FuncDecl.get_name decl) in (* ex. arg0 *)
+          let interp_opt = Z3.Model.get_const_interp model decl in (* ex. false *)
+          match interp_opt with
+          | None -> assert false
+          | Some interp -> 
+            BatMap.add name interp acc
+        ) decls BatMap.empty in
+        let cex_var_map = BatMap.foldi (fun id _ acc ->
+					let sexp = BatMap.find id name2expr in
+					BatMap.add id (Specification.sexp_to_const (Sexp.Atom (Z3.Expr.to_string sexp))) acc
+				) !forall_var_map BatMap.empty in
+				print_endline ("cex_var_map : " ^ (string_of_map (fun e -> e) string_of_const cex_var_map));
+				None
+;;
 
 let add_trivial_examples iospec target_function_name args_map =
 	let trivial_sol = 

--- a/src/logicalSpec.ml
+++ b/src/logicalSpec.ml
@@ -172,12 +172,14 @@ let get_counter_example sol target_function_name args_map =
         ) decls BatMap.empty in
 				(* (string, const) BatMap.t *)
         let cex_var_map = BatMap.foldi (fun id _ acc ->
-					let z3expr = BatMap.find id name2expr in
-					let sexp = Parsexp.Single.parse_string_exn (Z3.Expr.to_string z3expr) in
-					BatMap.add id (Const (List.hd (evaluate_expr_faster [[CInt 0]] (sexp_to_cex sexp)))) acc
+					try
+						let z3expr = BatMap.find id name2expr in
+						let sexp = Parsexp.Single.parse_string_exn (Z3.Expr.to_string z3expr) in
+						BatMap.add id (Const (List.hd (evaluate_expr_faster [[CInt 0]] (sexp_to_cex sexp)))) acc
+					(* don't care term *)
+					with _ -> BatMap.add id (Const (get_trivial_value (type_of_expr (BatMap.find id !forall_var_map)))) acc
 					(* BatMap.add id (Const (CInt (-2))) acc *)
 				) !forall_var_map BatMap.empty in
-				(* print_endline ("cex_var_map : " ^ (string_of_map (fun e -> e) string_of_expr cex_var_map)); *)
 				Some (cex_var_map)
 		end
 		in 

--- a/src/logicalSpec.ml
+++ b/src/logicalSpec.ml
@@ -5,18 +5,49 @@ open Z3
 open BidirectionalUtils
 
 type t = (Exprs.expr) list
-let empty_spec = []
+let empty_spec : t = []
 
 (* constraints that consist of logical spec *)
-let logical_spec = ref empty_spec
+let spec = ref empty_spec
 let add_constraint e = 
-	logical_spec := (e :: !logical_spec)
+	spec := (e :: !spec)
 
-let get_counter_example sol spec = 
-	if !logical_spec = [] then None (* can't found logical spec *)
+let string_of_logical_spec logical_spec = 
+	string_of_list string_of_expr logical_spec
+
+let rec resolve_expr sol target_function_name args_map expr  = 
+	match expr with
+	| Function (op, exprs, ty) -> 
+		begin
+			if op = target_function_name then
+				let param2var = 
+					BatMap.foldi (fun id param_expr acc ->
+						let ty = type_of_expr param_expr in 
+						BatMap.add param_expr (Var(id, ty)) acc  
+					) args_map BatMap.empty
+				in
+				change_param_to_var param2var expr
+			else
+				Function (op, BatList.map (resolve_expr sol target_function_name args_map) exprs, ty)
+		end
+	| _ -> expr
+
+let get_counter_example sol iospec target_function_name args_map = 
+	if !spec = [] then None (* can't found logical spec *)
 	else 
 		let ctx = Z3.mk_context	[("model", "true"); ("proof", "false")] in
 		(* STEP 01 : make logical spec to one expression (combine by 'and') *)
-		(* STEP 02 : resolve target function *)
+		let combined = BatList.fold_left (fun acc_expr e ->
+				(* STEP 02 : resolve target function *)
+				Function ("and", [acc_expr; (resolve_expr sol target_function_name args_map e)], Bool)
+			) (List.hd !spec) (List.tl !spec)
+		in
 		(* STEP 03 : make Z3 query *)
 		(* STEP 04 : get cex-in as counter example *)
+		None
+
+let add_trivial_examples iospec target_function_name args_map =
+	let trivial_sol = 
+		Exprs.Const (Exprs.get_trivial_value (Grammar.type_of_nt Grammar.start_nt))
+	in
+	get_counter_example trivial_sol iospec target_function_name args_map

--- a/src/main.ml
+++ b/src/main.ml
@@ -64,7 +64,7 @@ let main () =
 			in
 			let sol = 
 			if !LogicalSpec.do_enumeration then
-				(* let _ = print_endline "enumerating" in *)
+				let _ = print_endline "Found relational function. Do enumeration. It may takes more time than expected." in
 				Bottomup.synthesis (macro_instantiator, target_function_name, args_map, grammar, forall_var_map, spec) 
 			else 
 				let _ = assert ((List.length spec) > 0) in 

--- a/src/main.ml
+++ b/src/main.ml
@@ -25,9 +25,12 @@ let main () =
 				my_prerr_endline (Specification.string_of_io_spec spec);
 				my_prerr_endline (Printf.sprintf "CEGIS iter: %d" (List.length spec));
   			let sol =
-  				Bidirectional.synthesis
-						(macro_instantiator, target_function_name, grammar, forall_var_map, spec)
-  			in
+					try
+						Bidirectional.synthesis
+							(macro_instantiator, target_function_name, grammar, forall_var_map, spec)
+					with Failure _ ->
+						cegis (Compatibility.modify_spec spec)
+				in
 				my_prerr_endline (Printf.sprintf "** Proposed candidate: %s **" (Exprs.string_of_expr sol));
 				(* spec' = spec + mismatched input-output examples *)
 				let spec' = 

--- a/src/main.ml
+++ b/src/main.ml
@@ -47,12 +47,15 @@ let main () =
 				if (List.length spec) = (List.length spec') then 
 					match (if !Options.z3_cli then Specification.verify_cli else Specification.verify) sol spec with 
 					| None -> ( 
+							(* test if the cadidate always fulfils given logical solution *)
 							match (LogicalSpec.get_counter_example sol target_function_name args_map spec) with
 							| None -> 
+								(* no counter-example implies the candidate is a target program *)
 								prerr_endline ("# specs : " ^ (string_of_int (List.length spec)));
-								(* prerr_endline (Specification.string_of_io_spec spec); *)
 								sol
-							| Some new_spec -> cegis new_spec
+							| Some new_spec ->
+								(* There are some counter-exmaples. *)
+								cegis new_spec
 						)
 					| Some cex ->
 						my_prerr_endline (Specification.string_of_io_spec [cex]); 

--- a/src/main.ml
+++ b/src/main.ml
@@ -62,8 +62,12 @@ let main () =
 						cegis (cex :: spec')
 				else cegis spec'
 			in
-			let _ = assert ((List.length spec) > 0) in 
-			let sol =
+			let sol = 
+			if !LogicalSpec.do_enumeration then
+				(* let _ = print_endline "enumerating" in *)
+				Bottomup.synthesis (macro_instantiator, target_function_name, args_map, grammar, forall_var_map, spec) 
+			else 
+				let _ = assert ((List.length spec) > 0) in 
 				if !Options.ex_all then cegis spec_total 
 				else cegis [List.nth spec 0] 
 			in

--- a/src/main.ml
+++ b/src/main.ml
@@ -43,7 +43,19 @@ let main () =
 				(* no mismatched input-output examples *)
 				if (List.length spec) = (List.length spec') then 
 					match (if !Options.z3_cli then Specification.verify_cli else Specification.verify) sol spec with 
-					| None -> sol 
+					| None -> 
+						begin
+							match (LogicalSpec.get_counter_example sol target_function_name args_map) with
+							| None -> 
+								prerr_endline ("# specs : " ^ (string_of_int (List.length spec)));
+								(* prerr_endline (Specification.string_of_io_spec spec); *)
+								sol
+							| Some cex_all ->
+								let spec' = BatSet.fold (fun cex spec ->
+									Specification.add_io_spec cex spec
+								) cex_all spec in
+								cegis spec'
+						end
 					| Some cex ->
 						my_prerr_endline (Specification.string_of_io_spec [cex]); 
 						let _ = assert (not (List.mem cex spec')) in  

--- a/src/main.ml
+++ b/src/main.ml
@@ -43,19 +43,14 @@ let main () =
 				(* no mismatched input-output examples *)
 				if (List.length spec) = (List.length spec') then 
 					match (if !Options.z3_cli then Specification.verify_cli else Specification.verify) sol spec with 
-					| None -> 
-						begin
-							match (LogicalSpec.get_counter_example sol target_function_name args_map) with
+					| None -> ( 
+							match (LogicalSpec.get_counter_example sol target_function_name args_map spec) with
 							| None -> 
 								prerr_endline ("# specs : " ^ (string_of_int (List.length spec)));
 								(* prerr_endline (Specification.string_of_io_spec spec); *)
 								sol
-							| Some cex_all ->
-								let spec' = BatSet.fold (fun cex spec ->
-									Specification.add_io_spec cex spec
-								) cex_all spec in
-								cegis spec'
-						end
+							| Some new_spec -> cegis new_spec
+						)
 					| Some cex ->
 						my_prerr_endline (Specification.string_of_io_spec [cex]); 
 						let _ = assert (not (List.mem cex spec')) in  

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -252,6 +252,15 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 			let children = get_children exp in
 			let arg0 = BatList.nth children 0 in
 			let arg1 = BatList.nth children 1 in
+			let is_oracle_spec =
+				if (Exprs.is_function_expr arg0) && (Exprs.is_function_expr arg1) then 
+					let op0 = get_op arg0 in
+					let op1 = get_op arg1 in
+					((BatString.equal op0 target_function_name) && (BatMap.mem op1 macro_instantiator))
+					|| ((BatString.equal op1 target_function_name) && (BatMap.mem op0 macro_instantiator))
+				else
+					false
+			in
 			(* PBE spec: (f input) = output  *)
 			if (Exprs.is_const_expr arg0) || (Exprs.is_const_expr arg1) then
 				let inputs, output = 
@@ -264,7 +273,7 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 				let inputs = BatList.map expr2const inputs in   
 				Specification.add_io_spec (inputs, output) spec
 			(* Oracle spec: (f inputs) = (f' inputs) *)
-			else if (Exprs.is_function_expr arg0) && (Exprs.is_function_expr arg1) then 
+			else if is_oracle_spec then 
 				let oracle_expr, target_expr = 
 					if (BatString.equal (get_op arg0) target_function_name) then 
 						arg1, arg0

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -261,8 +261,19 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 				else
 					false
 			in
+			let is_pbe_spec =
+				if (Exprs.is_const_expr arg0) || (Exprs.is_const_expr arg1) then
+					let target_expr = if (Exprs.is_const_expr arg0) then arg1 else arg0 in
+					if (Exprs.is_function_expr target_expr) && (get_op target_expr) = target_function_name then 
+						let children = Exprs.get_children target_expr in
+						BatList.for_all (fun child -> Exprs.is_const_expr child) children
+					else 
+						false
+				else
+					false
+			in	
 			(* PBE spec: (f input) = output  *)
-			if (Exprs.is_const_expr arg0) || (Exprs.is_const_expr arg1) then
+			if is_pbe_spec then
 				let inputs, output = 
 					if (BatString.equal (get_op arg0) target_function_name) then 
 						(get_children arg0, expr2const arg1)
@@ -295,7 +306,8 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 				let _ = Specification.forall_var_map := forall_var_map in 
 				Specification.add_trivial_examples grammar spec
 			else 
-				failwith ("Not supported: synth-fun is missing")
+				let _ = LogicalSpec.add_constraint exp target_function_name in
+				spec
 		else
 			(* check if spec is reletional *)
 			let _ = LogicalSpec.add_constraint exp target_function_name in

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -241,7 +241,6 @@ let process_forall_vars forall_vars_data =
 (* [L[ A:= L[ A:hd20 A:x] L[ A:f A:x]]] *)
 (* (constraint (= (f #xeed40423e830e30d) #x8895fdee0be78e79)) *)
 (* [L[ A:= L[ A:f A:#xeed40423e830e30d] A:#x8895fdee0be78e79]] *) 
-(* currently, only for PBE *)
 (* return: spec as Exprs.expr *)
 let process_constraints grammar target_function_name constraints_data macro_instantiator id2var =
 	BatList.fold_left (fun spec constraint_data ->
@@ -277,7 +276,7 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 				let _ = Specification.oracle_expr := oracle_expr in
 				let _ = Specification.oracle_expr_resolved := oracle_expr_resolved in
 				(* forall_var_map : variable name -> Param(int, ty) *)
-				let _, forall_var_map = 
+				let _, forll_var_map = 
 					let args = get_children oracle_expr in 
 					List.fold_left (fun (i, m) var_expr ->
 						let name = Exprs.string_of_expr var_expr in 
@@ -288,7 +287,8 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 				Specification.add_trivial_examples grammar spec
 			else 
 				failwith ("Not supported: synth-fun is missing")
-		else failwith ("Not supported: not a SyGuS-pbe specification")
+		else
+			let _ = LogicalSpec.add_constraint exp in
 	) Specification.empty_spec constraints_data 
 
 let parse file = 

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -227,7 +227,71 @@ let process_synth_funcs synth_fun_data =
 	let ret_type = sexp_to_type ret_type_data in
 	let grammar = process_grammar args_map ret_type grammar_data in 
 	(name, args_map, grammar) 
-	
+
+let process_synth_invs synth_inv_data =
+	let _ = assert ((BatList.length synth_inv_data) = 4 || (BatList.length synth_inv_data) = 3) in  
+	let (name_data, args_data, ret_type_data) = 
+		(BatList.nth synth_inv_data 0, BatList.nth synth_inv_data 1, 
+		 BatList.nth synth_inv_data 2)
+	in
+	let grammar_data =
+		try BatList.nth synth_inv_data 3
+		with _ ->
+			Sexp.List [
+				Sexp.List [
+					Sexp.Atom "Start";
+					Sexp.Atom "Bool";
+					Sexp.List [
+						Sexp.Atom "true";
+						Sexp.Atom "false";
+						Sexp.List [Sexp.Atom "ite"; Sexp.Atom "Start"; Sexp.Atom "Start"; Sexp.Atom "Start"];
+						Sexp.List [Sexp.Atom "not"; Sexp.Atom "Start"];
+						Sexp.List [Sexp.Atom "and"; Sexp.Atom "Start"; Sexp.Atom "Start"];
+						Sexp.List [Sexp.Atom "or"; Sexp.Atom "Start"; Sexp.Atom "Start"];
+						Sexp.List [Sexp.Atom "="; Sexp.Atom "Start"; Sexp.Atom "Start"];
+						Sexp.List [Sexp.Atom "<"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+						Sexp.List [Sexp.Atom "<="; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+						Sexp.List [Sexp.Atom ">"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+						Sexp.List [Sexp.Atom ">="; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+						Sexp.List [Sexp.Atom "="; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+					]
+				];
+				Sexp.List [
+					Sexp.List [
+						Sexp.Atom "StartInt";
+						Sexp.Atom "Int";
+						Sexp.List [
+							Sexp.Atom "0";
+							Sexp.Atom "1";
+							Sexp.Atom "2";
+							Sexp.Atom "3";
+							Sexp.Atom "4";
+							Sexp.Atom "5";
+							Sexp.Atom "6";
+							Sexp.Atom "7";
+							Sexp.Atom "8";
+							Sexp.Atom "9";
+							Sexp.List [Sexp.Atom "ite"; Sexp.Atom "Start"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+							Sexp.List [Sexp.Atom "+"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+							Sexp.List [Sexp.Atom "-"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+							Sexp.List [Sexp.Atom "*"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+							Sexp.List [Sexp.Atom "/"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+							Sexp.List [Sexp.Atom "mod"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
+						]
+					]
+				]
+			] 
+		in
+	let name = Sexp.to_string name_data in
+	let args_map = get_args_map args_data in  
+	let ret_type = sexp_to_type ret_type_data in
+	let grammar = process_grammar args_map ret_type grammar_data 
+	in
+	(name, args_map, grammar) 
+
+(* (declare-var x (BitVec 64)) *)
+(* L[ A:declare-var L[ A:x L[ A:BitVec A:64]]] *)
+
 (* return: name -> Var expr *)
 let process_forall_vars forall_vars_data =
 	BatList.fold_left (fun m forall_var_data ->
@@ -374,7 +438,7 @@ let parse file =
 			else if (BatList.length synth_invs_data) > 1 then 
 				failwith "Multi-function synthesis is not supported."
 		in
-		 
+
 	end
 	else
 	begin

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -337,5 +337,6 @@ let parse file =
 	let constraints_data = filter_sexps_for "constraint" sexps in
 	(* prerr_endline (string_of_list string_of_sexp (BatSet.choose constraints_data)); *)
 	let spec = process_constraints grammar target_function_name constraints_data macro_instantiator id2var in
+	let _ = LogicalSpec.add_trivial_examples spec target_function_name args_map in
 	my_prerr_endline (Specification.string_of_io_spec spec);
 	(macro_instantiator, target_function_name, args_map, grammar, !Specification.forall_var_map, spec)  

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -339,6 +339,15 @@ let parse file =
 	(* prerr_endline (string_of_list string_of_sexp (BatSet.choose constraints_data)); *)
 	let spec = process_constraints grammar target_function_name constraints_data macro_instantiator id2var in
 	let _ = LogicalSpec.forall_var_map := id2var in (* to make Z3 query *)
-	let _ = LogicalSpec.add_trivial_examples spec target_function_name args_map in
+	let spec = 
+		let cex_all_opt = LogicalSpec.add_trivial_examples target_function_name args_map in
+		match cex_all_opt with
+		| None -> spec
+		| Some cex_all ->
+			BatSet.fold (fun cex spec ->
+				Specification.add_io_spec cex spec
+			) cex_all spec
+	in
 	my_prerr_endline (Specification.string_of_io_spec spec);
+	(* print_endline (Specification.string_of_io_spec spec); *)
 	(macro_instantiator, target_function_name, args_map, grammar, !Specification.forall_var_map, spec)  

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -288,6 +288,7 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 			else 
 				failwith ("Not supported: synth-fun is missing")
 		else
+			(* check if spec is reletional *)
 			let _ = LogicalSpec.add_constraint exp in
 			spec
 	) Specification.empty_spec constraints_data 
@@ -337,6 +338,7 @@ let parse file =
 	let constraints_data = filter_sexps_for "constraint" sexps in
 	(* prerr_endline (string_of_list string_of_sexp (BatSet.choose constraints_data)); *)
 	let spec = process_constraints grammar target_function_name constraints_data macro_instantiator id2var in
+	let _ = LogicalSpec.forall_var_map := forall_var_map in (* to make Z3 query *)
 	let _ = LogicalSpec.add_trivial_examples spec target_function_name args_map in
 	my_prerr_endline (Specification.string_of_io_spec spec);
 	(macro_instantiator, target_function_name, args_map, grammar, !Specification.forall_var_map, spec)  

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -358,30 +358,46 @@ let parse file =
 	(* ) macro_instantiator;                       *)
 	let synth_funs_data = filter_sexps_for "synth-fun" sexps in
 	let _ =
-		if (BatList.is_empty synth_funs_data) then
+		(* if (BatList.is_empty synth_funs_data) then
 			failwith "No target function to be synthesized is given."
 		else if (BatList.length synth_funs_data) > 1 then 
-			failwith "Multi-function synthesis is not supported." 
+			failwith "Multi-function synthesis is not supported."  *)
+		if (BatList.length synth_funs_data) > 1 then 
+			failwith "Multi-function synthesis is not supported."	 
 	in 
-	let target_function_name, args_map, grammar = 
-		process_synth_funcs (BatList.hd synth_funs_data) 
-	in 
-	(* prerr_endline (Grammar.string_of_grammar grammar); *)
-	let forall_vars_data = filter_sexps_for "declare-var" sexps in
-	let id2var = process_forall_vars forall_vars_data in  
-	let constraints_data = filter_sexps_for "constraint" sexps in
-	(* prerr_endline (string_of_list string_of_sexp (BatSet.choose constraints_data)); *)
-	let spec = process_constraints grammar target_function_name constraints_data macro_instantiator id2var in
-	let _ = LogicalSpec.forall_var_map := id2var in (* to make Z3 query *)
-	let spec = 
-		let cex_all_opt = LogicalSpec.add_trivial_examples target_function_name args_map in
-		match cex_all_opt with
-		| None -> spec
-		| Some cex_all ->
-			BatSet.fold (fun cex spec ->
-				Specification.add_io_spec cex spec
-			) cex_all spec
-	in
-	my_prerr_endline (Specification.string_of_io_spec spec);
-	(* print_endline (Specification.string_of_io_spec spec); *)
-	(macro_instantiator, target_function_name, args_map, grammar, !Specification.forall_var_map, spec)  
+	if (BatList.is_empty synth_funs_data) then
+	begin
+		let synth_invs_data = filter_sexps_for "synth-inv" sexps in
+		let _ = 
+			if (BatList.is_empty synth_invs_data) then
+				failwith "No target function to be synthesized is given."
+			else if (BatList.length synth_invs_data) > 1 then 
+				failwith "Multi-function synthesis is not supported."
+		in
+		 
+	end
+	else
+	begin
+		let target_function_name, args_map, grammar = 
+			process_synth_funcs (BatList.hd synth_funs_data) 
+		in 
+		(* prerr_endline (Grammar.string_of_grammar grammar); *)
+		let forall_vars_data = filter_sexps_for "declare-var" sexps in
+		let id2var = process_forall_vars forall_vars_data in  
+		let constraints_data = filter_sexps_for "constraint" sexps in
+		(* prerr_endline (string_of_list string_of_sexp (BatSet.choose constraints_data)); *)
+		let spec = process_constraints grammar target_function_name constraints_data macro_instantiator id2var in
+		let _ = LogicalSpec.forall_var_map := id2var in (* to make Z3 query *)
+		let spec = 
+			let cex_all_opt = LogicalSpec.add_trivial_examples target_function_name args_map in
+			match cex_all_opt with
+			| None -> spec
+			| Some cex_all ->
+				BatSet.fold (fun cex spec ->
+					Specification.add_io_spec cex spec
+				) cex_all spec
+		in
+		my_prerr_endline (Specification.string_of_io_spec spec);
+		(* print_endline (Specification.string_of_io_spec spec); *)
+		(macro_instantiator, target_function_name, args_map, grammar, !Specification.forall_var_map, spec)  
+	end

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -61,7 +61,10 @@ let rec sexp_to_expr sexp args_map =
 		let expr_ty = 
 			try Grammar.ret_type_of_op (Grammar.FuncRewrite (op, []))
 			(* TODO : macro *)
-			with _ -> type_of_nt (Grammar.start_nt) (* maybe target-function *)
+			with _ -> (
+				try type_of_nt (Grammar.start_nt) (* maybe target-function *)
+				with _ -> sexp_to_type sexp
+			)
 		in 
 		Function (op, children, expr_ty)
 	| Sexp.Atom s ->

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -234,14 +234,22 @@ let process_synth_invs synth_inv_data =
 		(BatList.nth synth_inv_data 0, BatList.nth synth_inv_data 1, 
 		 try BatList.nth synth_inv_data 2 with _ -> Sexp.Atom "Bool")
 	in
+	let args_map = get_args_map args_data in  
 	let grammar_data =
 		try BatList.nth synth_inv_data 3
 		with _ ->
 			Sexp.List [
 				Sexp.List [
 					Sexp.Atom "Start";
-					Sexp.Atom "Bool";
-					Sexp.List [
+					Sexp.Atom "Bool"; 
+					Sexp.List (BatMap.foldi (fun id param acc ->
+						match param with
+						| Param(i, ty) -> 
+							if ty = Bool then 
+								acc @ [Sexp.Atom id]
+							else acc
+						| _ -> assert false
+					)	args_map [
 						Sexp.Atom "true";
 						Sexp.Atom "false";
 						Sexp.List [Sexp.Atom "ite"; Sexp.Atom "Start"; Sexp.Atom "Start"; Sexp.Atom "Start"];
@@ -254,12 +262,19 @@ let process_synth_invs synth_inv_data =
 						Sexp.List [Sexp.Atom ">"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
 						Sexp.List [Sexp.Atom ">="; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
 						Sexp.List [Sexp.Atom "="; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
-					]
+					])
 				];
 				Sexp.List [
 					Sexp.Atom "StartInt";
 					Sexp.Atom "Int";
-					Sexp.List [
+					Sexp.List (BatMap.foldi (fun id param acc ->
+						match param with
+						| Param(i, ty) -> 
+							if ty = Int then 
+								acc @ [Sexp.Atom id]
+							else acc
+						| _ -> assert false
+					)	args_map [
 						Sexp.Atom "0";
 						Sexp.Atom "1";
 						Sexp.Atom "2";
@@ -276,12 +291,11 @@ let process_synth_invs synth_inv_data =
 						Sexp.List [Sexp.Atom "*"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
 						Sexp.List [Sexp.Atom "/"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
 						Sexp.List [Sexp.Atom "mod"; Sexp.Atom "StartInt"; Sexp.Atom "StartInt"];
-					]
+					])
 				]
 			] 
 		in
-	let name = Sexp.to_string name_data in
-	let args_map = get_args_map args_data in  
+	let name = Sexp.to_string name_data in 
 	let ret_type = sexp_to_type ret_type_data in
 	let grammar = process_grammar args_map ret_type grammar_data 
 	in

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -58,7 +58,11 @@ let rec sexp_to_expr sexp args_map =
 		let children = 
 			BatList.map (fun sexp' -> sexp_to_expr sexp' args_map) sexps'
 		in  
-		let expr_ty = sexp_to_type sexp in 
+		let expr_ty = 
+			try Grammar.ret_type_of_op (Grammar.FuncRewrite (op, []))
+			(* TODO : macro *)
+			with _ -> type_of_nt (Grammar.start_nt) (* maybe target-function *)
+		in 
 		Function (op, children, expr_ty)
 	| Sexp.Atom s ->
 		let id = (Sexp.to_string sexp) in 

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -310,10 +310,19 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 				let _ = Specification.forall_var_map := forall_var_map in 
 				Specification.add_trivial_examples grammar spec
 			else 
+				let _ =
+					try 
+						assert ((BatMap.cardinal macro_instantiator) = 0)
+					with _ -> failwith "Non-oracle spec cannot be mixed with macro definitions.";
+				in
 				let _ = LogicalSpec.add_constraint exp target_function_name in
 				spec
 		else
-			(* check if spec is reletional *)
+			let _ =
+				try 
+					assert ((BatMap.cardinal macro_instantiator) = 0)
+				with _ -> failwith "Non-oracle spec cannot be mixed with macro definitions.";
+			in
 			let _ = LogicalSpec.add_constraint exp target_function_name in
 			spec
 	) Specification.empty_spec constraints_data 

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -289,7 +289,7 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 				failwith ("Not supported: synth-fun is missing")
 		else
 			(* check if spec is reletional *)
-			let _ = LogicalSpec.add_constraint exp in
+			let _ = LogicalSpec.add_constraint exp target_function_name in
 			spec
 	) Specification.empty_spec constraints_data 
 
@@ -338,7 +338,7 @@ let parse file =
 	let constraints_data = filter_sexps_for "constraint" sexps in
 	(* prerr_endline (string_of_list string_of_sexp (BatSet.choose constraints_data)); *)
 	let spec = process_constraints grammar target_function_name constraints_data macro_instantiator id2var in
-	let _ = LogicalSpec.forall_var_map := forall_var_map in (* to make Z3 query *)
+	let _ = LogicalSpec.forall_var_map := id2var in (* to make Z3 query *)
 	let _ = LogicalSpec.add_trivial_examples spec target_function_name args_map in
 	my_prerr_endline (Specification.string_of_io_spec spec);
 	(macro_instantiator, target_function_name, args_map, grammar, !Specification.forall_var_map, spec)  

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -276,7 +276,7 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 				let _ = Specification.oracle_expr := oracle_expr in
 				let _ = Specification.oracle_expr_resolved := oracle_expr_resolved in
 				(* forall_var_map : variable name -> Param(int, ty) *)
-				let _, forll_var_map = 
+				let _, forall_var_map = 
 					let args = get_children oracle_expr in 
 					List.fold_left (fun (i, m) var_expr ->
 						let name = Exprs.string_of_expr var_expr in 
@@ -289,6 +289,7 @@ let process_constraints grammar target_function_name constraints_data macro_inst
 				failwith ("Not supported: synth-fun is missing")
 		else
 			let _ = LogicalSpec.add_constraint exp in
+			spec
 	) Specification.empty_spec constraints_data 
 
 let parse file = 

--- a/src/specification.ml
+++ b/src/specification.ml
@@ -14,7 +14,14 @@ let sexp_to_const sexp =
 		(CBV (Int64.of_string ("0" ^ (BatString.lchop ~n:1 str))))		
 	else if (str.[0] = '\"') then
 		(* let _ = prerr_endline str in *)
-		(CString (BatString.replace_chars (function '\"' -> "" | ';' -> "" | c -> BatString.make 1 c) str))
+		(* TODO : make it available if only logic is LIA *)
+		let re = Str.regexp {|"(- \([0-9]+\))"|} in
+		if (Str.string_match re str 0) then 
+			(* when I got "(- 1)" *)
+			CInt (- (int_of_string (Str.matched_group 1 str)))
+		else
+			(* otherwise *)
+			(CString (BatString.replace_chars (function '\"' -> "" | ';' -> "" | c -> BatString.make 1 c) str))
 	else 
 		try (CInt (int_of_string str)) with _ -> (CString str)
 		

--- a/src/specification.ml
+++ b/src/specification.ml
@@ -14,14 +14,7 @@ let sexp_to_const sexp =
 		(CBV (Int64.of_string ("0" ^ (BatString.lchop ~n:1 str))))		
 	else if (str.[0] = '\"') then
 		(* let _ = prerr_endline str in *)
-		(* TODO : make it available if only logic is LIA *)
-		let re = Str.regexp {|"(- \([0-9]+\))"|} in
-		if (Str.string_match re str 0) then 
-			(* when I got "(- 1)" *)
-			CInt (- (int_of_string (Str.matched_group 1 str)))
-		else
-			(* otherwise *)
-			(CString (BatString.replace_chars (function '\"' -> "" | ';' -> "" | c -> BatString.make 1 c) str))
+		(CString (BatString.replace_chars (function '\"' -> "" | ';' -> "" | c -> BatString.make 1 c) str))
 	else 
 		try (CInt (int_of_string str)) with _ -> (CString str)
 		


### PR DESCRIPTION
## Minor fix
exprs.ml : can use '-' as uniary operator, 'mod' is equals to '%'
grammar.ml : add '=>' (implies)

## Major fix
parse.ml : can parse logical specification as well as invariant synthesis
bottomup.ml : don't care io-spec when do enumeration
main.ml : modify CEGIS loop for logical specification
logicalSpec.ml : get io-spec from logical spec using Z3
compatitability.ml : support invariant synthesis by detecting a paradox within io-spec 